### PR TITLE
Feature/linux dmg support

### DIFF
--- a/lib/macos.js
+++ b/lib/macos.js
@@ -10,6 +10,99 @@ var path            = require( 'path' );
 var writeConfigFile = require( './helper/writeConfigFile' );
 var assign          = require( 'lodash.assign' );
 var os              = require( 'os' );
+var childProcess    = require( 'child_process' );
+
+/**
+ * Build the installer for macos using appdmg, when on the darwin platform
+ *
+ * @param  {Object}   options  options
+ * @param  {Function} callback callback
+ */
+function buildDarwin( options, callback ) {
+
+  options.log( 'Writing temporary ´appdmg.json´' );
+
+  options.config.macos.background         = path.join( options.basePath, options.config.macos.background );
+  options.config.macos.icon               = path.join( options.basePath, options.config.macos.icon );
+  options.config.macos.contents[ 1 ].path = options.appPath;
+
+  var configFilePath = path.join( os.tmpDir(), 'appdmg.json' );
+
+  fs.writeFileSync(
+    configFilePath,
+    JSON.stringify( options.config.macos ),
+    {
+      encoding : 'utf8'
+    }
+  );
+
+  options.log( 'Wrote temporary ´appdmg.json´' );
+  options.log( 'Kicking off ´appdmg´' );
+
+  var appdmg = require( 'appdmg' );
+  var ee = appdmg( {
+    source : configFilePath,
+    target : path.join( options.out, options.config.macos.title + '.dmg' )
+  } );
+
+  ee.on( 'progress', function ( info ) {
+    if ( info.type === 'step-begin' ) {
+      options.log( 'appdmg: [' + info.current + '] ' + info.title  );
+    }
+  } );
+
+  ee.on('finish', function () {
+    options.log( 'Finished ´appdmg´' );
+    callback();
+  } );
+
+  ee.on( 'error', function ( error ) {
+    callback( error );
+  } );
+
+}
+
+/**
+ * Build the installer for macos using genisoimage, when on the linux platform
+ *
+ * @param  {Object}   options  options
+ * @param  {Function} callback callback
+ */
+function buildLinux( options, callback ) {
+
+  options.log( 'Kicking off ´genisoimage´' );
+
+  var title = options.config.macos.title
+  var genisoimage = childProcess.spawn(
+    'genisoimage',
+    [ '-V', title, '-D', '-R', '-apple', '-no-pad', '-o', path.join(options.out, title + '.dmg'), '-graft-points', title + '.app=' + options.appPath ],
+    {
+      env   : process.env
+    }
+  );
+
+  genisoimage.stdout.on( 'data', function ( data ) {
+    options.log( 'genisoimage: ' + data );
+  });
+
+  genisoimage.on( 'error', function ( err ) {
+    return callback(err);
+  });
+
+  genisoimage.on( 'close', function ( code ) {
+    options.log( 'Finished genisoimage with code ' + code );
+
+    if ( code > 0 ) {
+      return callback( new Error( 'genisoimage failed' ) );
+    }
+
+    callback();
+  });
+
+  if ( genisoimage.error || genisoimage.status > 0 ) {
+    return callback( genisoimage.error || new Error( 'genisoimage failed' ) );
+  }
+}
 
 /**
  * Prototype for the macos installer builder
@@ -36,103 +129,7 @@ var MacosBuilder = {
       default:
         return callback( new Error( 'Invalid platform.' ) ); // win32 not currently supported.
     }
-  },
-
-  /**
-   * Build the installer for macos using appdmg, when on the darwin platform
-   *
-   * @param  {Object}   options  options
-   * @param  {Function} callback callback
-   */
-  buildDarwin: function( options, callback ) {
-
-    options.log( 'Writing temporary ´appdmg.json´' );
-
-    options.config.macos.background         = path.join( options.basePath, options.config.macos.background );
-    options.config.macos.icon               = path.join( options.basePath, options.config.macos.icon );
-    options.config.macos.contents[ 1 ].path = options.appPath;
-
-    var configFilePath = path.join( os.tmpDir(), 'appdmg.json' );
-
-    fs.writeFileSync(
-      configFilePath,
-      JSON.stringify( options.config.macos ),
-      {
-        encoding : 'utf8'
-      }
-    );
-
-    options.log( 'Wrote temporary ´appdmg.json´' );
-    options.log( 'Kicking off ´appdmg´' );
-
-    var appdmg = require( 'appdmg' );
-    var ee = appdmg( {
-      source : configFilePath,
-      target : path.join( options.out, options.config.macos.title + '.dmg' )
-    } );
-
-    ee.on( 'progress', function ( info ) {
-      if ( info.type === 'step-begin' ) {
-        options.log( 'appdmg: [' + info.current + '] ' + info.title  );
-      }
-    } );
-
-    ee.on('finish', function () {
-      options.log( 'Finished ´appdmg´' );
-      callback();
-    } );
-
-    ee.on( 'error', function ( error ) {
-      callback( error );
-    } );
-
-  },
-
-  /**
-   * Build the installer for macos using genisoimage, when on the linux platform
-   *
-   * @param  {Object}   options  options
-   * @param  {Function} callback callback
-   */
-  buildLinux : function( options, callback ) {
-
-    options.log( 'Kicking off ´genisoimage´' );
-
-    var title = options.config.darwin.title
-    var genisoimage = childProcess.spawn(
-      'genisoimage',
-      [ '-V', title, '-D', '-R', '-apple', '-no-pad', '-o', path.join(options.out, title + '.dmg'), '-graft-points', title + '.app=' + options.appPath ],
-      {
-        env   : process.env
-      }
-    );
-
-    genisoimage.stdout.on( 'data', function ( data ) {
-      options.log( 'genisoimage: ' + data );
-    } );
-
-    genisoimage.stderr.on( 'data', function ( data ) {
-      options.log('genisoimage error: ' + data);
-    });
-
-    genisoimage.on( 'error', function ( err ) {
-      return callback(err);
-    });
-
-    genisoimage.on( 'close', function ( code ) {
-      options.log( 'Finished genisoimage with code ' + code );
-
-      if ( code > 0 ) {
-        return callback( new Error( 'genisoimage failed' ) );
-      }
-
-      callback();
-    });
-
-    if ( genisoimage.error || genisoimage.status > 0 ) {
-      return callback( genisoimage.error || new Error( 'genisoimage failed' ) );
-    }
-  },
+  }
 };
 
 

--- a/lib/macos.js
+++ b/lib/macos.js
@@ -24,9 +24,27 @@ var MacosBuilder = {
    */
   build : function( options, callback ) {
 
-    if ( process.platform !== 'darwin' ) return callback( new Error( 'Invalid platform.' ) )
-
     options.log( '- Starting build for ´' + options.platform + '´ - ' );
+
+    switch( process.platform ) {
+      case 'darwin':
+        buildDarwin(options, callback);
+        break;
+      case 'linux':
+        buildLinux(options, callback);
+        break;
+      default:
+        return callback( new Error( 'Invalid platform.' ) ); // win32 not currently supported.
+    }
+  },
+
+  /**
+   * Build the installer for macos using appdmg, when on the darwin platform
+   *
+   * @param  {Object}   options  options
+   * @param  {Function} callback callback
+   */
+  buildDarwin: function( options, callback ) {
 
     options.log( 'Writing temporary ´appdmg.json´' );
 
@@ -67,7 +85,54 @@ var MacosBuilder = {
     ee.on( 'error', function ( error ) {
       callback( error );
     } );
-  }
+
+  },
+
+  /**
+   * Build the installer for macos using genisoimage, when on the linux platform
+   *
+   * @param  {Object}   options  options
+   * @param  {Function} callback callback
+   */
+  buildLinux : function( options, callback ) {
+
+    options.log( 'Kicking off ´genisoimage´' );
+
+    var title = options.config.darwin.title
+    var genisoimage = childProcess.spawn(
+      'genisoimage',
+      [ '-V', title, '-D', '-R', '-apple', '-no-pad', '-o', path.join(options.out, title + '.dmg'), '-graft-points', title + '.app=' + options.appPath ],
+      {
+        env   : process.env
+      }
+    );
+
+    genisoimage.stdout.on( 'data', function ( data ) {
+      options.log( 'genisoimage: ' + data );
+    } );
+
+    genisoimage.stderr.on( 'data', function ( data ) {
+      options.log('genisoimage error: ' + data);
+    });
+
+    genisoimage.on( 'error', function ( err ) {
+      return callback(err);
+    });
+
+    genisoimage.on( 'close', function ( code ) {
+      options.log( 'Finished genisoimage with code ' + code );
+
+      if ( code > 0 ) {
+        return callback( new Error( 'genisoimage failed' ) );
+      }
+
+      callback();
+    });
+
+    if ( genisoimage.error || genisoimage.status > 0 ) {
+      return callback( genisoimage.error || new Error( 'genisoimage failed' ) );
+    }
+  },
 };
 
 

--- a/lib/platforms.js
+++ b/lib/platforms.js
@@ -7,6 +7,7 @@
 
 module.exports = {
   macos : require( './macos' ),
+  darwin: require( './macos' ),
   win   : require( './win' ),
   win32 : require( './win' )
 };


### PR DESCRIPTION
This PR adds the ability to generate macos .dmg files when running on linux. Combined with the merged branch `justin/win32-support` this allows linux to build both windows and mac installers, which allows us to generate said installers from a single build on travis-ci.

This PR passes `npm test`