### PR TITLE
Feature(fileName): Add additional option to include a file name separate from the title.

### DIFF
--- a/lib/osx.js
+++ b/lib/osx.js
@@ -50,9 +50,10 @@ var OSXBuilder = {
     options.log( 'Kicking off ´appdmg´' );
 
     var appdmg = require( 'appdmg' );
+    var fileName = options.config.osx.fileName ? options.config.osx.fileName : options.config.osx.title;
     var ee = appdmg( {
       source : configFilePath,
-      target : path.join( options.out, options.config.osx.title + '.dmg' )
+      target : path.join( options.out, fileName + '.dmg' )
     } );
 
     ee.on( 'progress', function ( info ) {

--- a/lib/win.js
+++ b/lib/win.js
@@ -27,11 +27,16 @@ var WinBuilder = {
   build : function( options, callback ) {
     options.log( '- Starting build for ´' + options.platform + '´ - ' );
 
-    var configFilePath = writeConfigFile( 'installer.nsi', {
+    var fileName = options.config.win.fileName ? options.config.win.fileName : [options.config.win.title, 'Setup'].join(' ');
+
+    var config =  {
       appPath : _windowsify( options.appPath ),
       name    : options.config.win.title,
+      fileName: fileName,
       out     : _windowsify( options.out )
-    } );
+    };
+
+    var configFilePath = writeConfigFile( 'installer.nsi', config);
 
     _copyAssetsToTmpFolder( options );
 

--- a/lib/win.js
+++ b/lib/win.js
@@ -27,16 +27,16 @@ var WinBuilder = {
   build : function( options, callback ) {
     options.log( '- Starting build for ´' + options.platform + '´ - ' );
 
-    var fileName = options.config.win.fileName ? options.config.win.fileName : [options.config.win.title, 'Setup'].join(' ');
+    var fileName = options.config.win.fileName ? options.config.win.fileName : [ options.config.win.title, 'Setup' ].join( ' ' );
 
     var config =  {
-      appPath : _windowsify( options.appPath ),
-      name    : options.config.win.title,
-      fileName: fileName,
-      out     : _windowsify( options.out )
+      appPath  : _windowsify( options.appPath ),
+      name     : options.config.win.title,
+      fileName : fileName,
+      out      : _windowsify( options.out )
     };
 
-    var configFilePath = writeConfigFile( 'installer.nsi', config);
+    var configFilePath = writeConfigFile( 'installer.nsi', config );
 
     _copyAssetsToTmpFolder( options );
 

--- a/templates/installer.nsi.tpl
+++ b/templates/installer.nsi.tpl
@@ -1,5 +1,6 @@
 !define APP_NAME "<%= name %>"
 !define APP_DIR "${APP_NAME}"
+!define APP_FILE_NAME "<%= fileName %>"
 
 Name "${APP_NAME}"
 
@@ -11,7 +12,7 @@ Name "${APP_NAME}"
 
 
 # define the resulting installer's name
-OutFile "<%= out %>\${APP_NAME} Setup.exe"
+OutFile "<%= out %>\${APP_FILE_NAME}.exe"
 
 # set the installation directory
 InstallDir "$PROGRAMFILES\${APP_NAME}\"


### PR DESCRIPTION
First off, thank you very much for developing this tool. It's worked great.

I've thrown together a quick PR to add the option of passing a fileName to name the Mac OSX DMG.

If no 'fileName' is provided, use the title as before.

Ran tests and they still pass.

