### PR TITLE
Clarify Linux install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,17 +41,17 @@ If you're on OS X/Linux and want to build for Windows, you need Wine installed. 
 
 You will also need the nullsoft scriptable install system for all platforms.
 
-On OS X via brew
+On OS X, via Homebrew
 ```
 $ brew install wine makensis
 ```
-On linux via apt-get
+On Ubuntu(-based) Linux distributions, via apt:
 ```
-$ add-apt-repository ppa:ubuntu-wine/ppa -y
-$ apt-get update
-$ apt-get install wine nsis -y
+# add-apt-repository ppa:ubuntu-wine/ppa -y
+# apt-get update
+# apt-get install wine nsis -y
 ```
-On Windows download the [nullsoft scriptable installer](http://nsis.sourceforge.net/Download)
+On Windows, download the [nullsoft scriptable installer](http://nsis.sourceforge.net/Download)
 
 If you're on OS X/Linux and want to build for Windows, make also sure you're running at least `v0.12.0` of node.js.
 


### PR DESCRIPTION
* Clarify that the Linux instructions are specifically for Ubuntu & its derived distributions
* Hint that `add-apt-repository` and `apt-get` usually require superuser privileges
* Other typographical changes in the vicinity