### PR TITLE
Update desktop shortcut to use icon.ico

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Your application mount icon.
 Sizes of the icons included in `dmg` dialog.
 
 ### `osx.contents`
-Icons you wish to include in `dmg` dialog.
+This property contains the configuration for the OSX dmg window. This property is passed to `appdmg`, which builds the dmg package. For a deeper explanation of the different options that you can set in this property, visit [`appdmg`'s page](https://www.npmjs.com/package/appdmg).
 
 ### `win.title`
 Title of your application shown in generated windows installer.

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Your application mount icon.
 Sizes of the icons included in `dmg` dialog.
 
 ### `osx.contents`
-This property contains the configuration for the OSX dmg window. This property is passed to `appdmg`, which builds the dmg package. For a deeper explanation of the different options that you can set in this property, visit [`appdmg`'s page](https://www.npmjs.com/package/appdmg).
+Icons you wish to include in `dmg` dialog.
 
 ### `win.title`
 Title of your application shown in generated windows installer.

--- a/templates/installer.nsi.tpl
+++ b/templates/installer.nsi.tpl
@@ -50,7 +50,7 @@ Section
   CreateDirectory "$SMPROGRAMS\${APP_DIR}"
   CreateShortCut "$SMPROGRAMS\${APP_DIR}\${APP_NAME}.lnk" "$INSTDIR\${APP_NAME}.exe"
   CreateShortCut "$SMPROGRAMS\${APP_DIR}\Uninstall ${APP_NAME}.lnk" "$INSTDIR\Uninstall ${APP_NAME}.exe"
-  CreateShortCut "$DESKTOP\${APP_NAME}.lnk" "$INSTDIR\${APP_NAME}.exe"
+  CreateShortCut "$DESKTOP\${APP_NAME}.lnk" "$INSTDIR\${APP_NAME}.exe" "" "$INSTDIR\icon.ico"
 
   WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}" \
                    "DisplayName" "${APP_NAME}"


### PR DESCRIPTION
With these extra params, the Desktop shortcut that is created will have the icon of the icon provided in the config file. Without this change, I couldn't get the desktop icon to use the icon that I was providing in the config file.