### PR TITLE
Update readme description for osx.contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Your application mount icon.
 Sizes of the icons included in `dmg` dialog.
 
 ### `osx.contents`
-Icons you wish to include in `dmg` dialog.
+This property contains the configuration for the OSX dmg window. This property is passed to `appdmg`, which builds the dmg package. For a deeper explanation of the different options that you can set in this property, visit [`appdmg`'s page](https://www.npmjs.com/package/appdmg).
 
 ### `win.title`
 Title of your application shown in generated windows installer.

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Your application mount icon.
 Sizes of the icons included in `dmg` dialog.
 
 ### `osx.contents`
-This property contains the configuration for the OSX dmg window. This property is passed to `appdmg`, which builds the dmg package. For a deeper explanation of the different options that you can set in this property, visit [`appdmg`'s page](https://www.npmjs.com/package/appdmg).
+Icons you wish to include in `dmg` dialog.
 
 ### `win.title`
 Title of your application shown in generated windows installer.

--- a/templates/installer.nsi.tpl
+++ b/templates/installer.nsi.tpl
@@ -50,7 +50,7 @@ Section
   CreateDirectory "$SMPROGRAMS\${APP_DIR}"
   CreateShortCut "$SMPROGRAMS\${APP_DIR}\${APP_NAME}.lnk" "$INSTDIR\${APP_NAME}.exe"
   CreateShortCut "$SMPROGRAMS\${APP_DIR}\Uninstall ${APP_NAME}.lnk" "$INSTDIR\Uninstall ${APP_NAME}.exe"
-  CreateShortCut "$DESKTOP\${APP_NAME}.lnk" "$INSTDIR\${APP_NAME}.exe"
+  CreateShortCut "$DESKTOP\${APP_NAME}.lnk" "$INSTDIR\${APP_NAME}.exe" "" "$INSTDIR\icon.ico"
 
   WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}" \
                    "DisplayName" "${APP_NAME}"

--- a/templates/installer.nsi.tpl
+++ b/templates/installer.nsi.tpl
@@ -50,7 +50,7 @@ Section
   CreateDirectory "$SMPROGRAMS\${APP_DIR}"
   CreateShortCut "$SMPROGRAMS\${APP_DIR}\${APP_NAME}.lnk" "$INSTDIR\${APP_NAME}.exe"
   CreateShortCut "$SMPROGRAMS\${APP_DIR}\Uninstall ${APP_NAME}.lnk" "$INSTDIR\Uninstall ${APP_NAME}.exe"
-  CreateShortCut "$DESKTOP\${APP_NAME}.lnk" "$INSTDIR\${APP_NAME}.exe" "" "$INSTDIR\icon.ico"
+  CreateShortCut "$DESKTOP\${APP_NAME}.lnk" "$INSTDIR\${APP_NAME}.exe"
 
   WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}" \
                    "DisplayName" "${APP_NAME}"


### PR DESCRIPTION
added some info that I needed to better understand the `osx.contents` property of the config.json file. It was helpful to understand that it was using appdmg and the description on appdmg's npmjs page really helped me understand what all the properties meant, and how I could use them more effectively. It took me a while to find it, however. I had to ask through the Slack channel, and finally someone pointed me at appdmg's page. Then it all just clicked. Hopefully this will make it easier for the next person to catch the vision here. 