### PR TITLE
Updated "How we used it so far" part of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,9 +180,9 @@ package.json
   "scripts": {
     "dev": "electron ./app",
 
-    "clean": "rm -rf ./dist",
-    "clean:osx": "rm -rf ./dist/osx",
-    "clean:win": "rm -rf ./dist/win",
+    "clean": "rimraf ./dist",
+    "clean:osx": "rimraf ./dist/osx",
+    "clean:win": "rimraf ./dist/win",
 
     "build": "npm run clean && npm run build:osx && npm run build:win",
     "build:osx": "npm run clean:osx && electron-packager ./app \"Loopline Systems\" --out=dist/osx --platform=darwin --arch=x64 --version=0.25.3 --icon=assets/osx/loopline.icns",


### PR DESCRIPTION
Fix: changed `rm -rf` (which doesn't work on win7 x86) for `rimraf`.