### PR TITLE
nsi.template update to fix missing desktop icon

### DIFF
--- a/templates/installer.nsi.tpl
+++ b/templates/installer.nsi.tpl
@@ -50,7 +50,7 @@ Section
   CreateDirectory "$SMPROGRAMS\${APP_DIR}"
   CreateShortCut "$SMPROGRAMS\${APP_DIR}\${APP_NAME}.lnk" "$INSTDIR\${APP_NAME}.exe"
   CreateShortCut "$SMPROGRAMS\${APP_DIR}\Uninstall ${APP_NAME}.lnk" "$INSTDIR\Uninstall ${APP_NAME}.exe"
-  CreateShortCut "$DESKTOP\${APP_NAME}.lnk" "$INSTDIR\${APP_NAME}.exe"
+  CreateShortCut "$DESKTOP\${APP_NAME}.lnk" "$INSTDIR\${APP_NAME}.exe" "" "$INSTDIR\icon.ico"
 
   WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}" \
                    "DisplayName" "${APP_NAME}"


### PR DESCRIPTION
Added some extras to the nsi template. When I added this, the desktop icon of the installed app was the icon that I provide, and not the default Electron icon. Without this, the app installs and the desktop icon is the Electron icon. So, this was a definite upgrade. I tested this on Win7 and Win10.