### PR TITLE
Add keywords to improve discoverability

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,23 @@
     "url": "https://github.com/loopline-systems/electron-builder.git"
   },
   "keywords": [
-    "electron"
+    "electron",
+    "builder",
+    "build",
+    "installer",
+    "install",
+    "packager",
+    "pack",
+    "nsis",
+    "appdmg",
+    "app",
+    "dmg",    
+    "msi",
+    "exe",
+    "setup",
+    "Windows",
+    "OS X",
+    "Mac"
   ],
   "bin": {
     "electron-builder": "cli.js"


### PR DESCRIPTION
It's difficult to find `electron-builder` on [npmjs.com](https://www.npmjs.com/). For example if you search for [electron installer](https://www.npmjs.com/search?q=electron+installer), it's not even listed.
I added a bunch of keywords that users might use when trying to find a solution for building/generating Electron installers. It should improve the discoverability of this project.