### PR TITLE
Fix problem creating nested directories with no parent

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@
 var platforms = require( './lib/platforms' );
 var path      = require( 'path' );
 var fs        = require( 'fs' );
+var mkdirp    = require( 'mkdirp' );
 
 /**
  * Prototype for electron-builder
@@ -42,7 +43,7 @@ var Builder = {
     // directory exists
     if ( !fs.existsSync( options.out ) ) {
       options.log( '- Ouput directory ´' + options.out + '´ does not exist ' );
-      fs.mkdirSync( options.out );
+      mkdirp.sync( options.out );
       options.log( '- Created ´' + options.out + '´ ' );
     }
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "lodash.assign": "^3.2.0",
     "lodash.camelcase": "^3.0.1",
     "lodash.template": "^3.6.1",
-    "meow": "^3.1.0"
+    "meow": "^3.1.0",
+    "mkdirp": "^0.5.1"
   },
   "optionalDependencies": {
     "appdmg": "^0.3.1"


### PR DESCRIPTION
I was getting this error before my fixing:

```
- Running electron-builder 2.2.0
- Ouput directory ´/Users/maxcnunes/Development/sqlectron/sqlectron-gui/dist/installers/osx/´ does not exist
fs.js:747
  return binding.mkdir(pathModule._makeLong(path),
                 ^
Error: ENOENT, no such file or directory '/Users/maxcnunes/Development/sqlectron/sqlectron-gui/dist/installers/osx/'
    at Error (native)
    at Object.fs.mkdirSync (fs.js:747:18)
    at Object.Builder.build (/Users/maxcnunes/Development/sqlectron/sqlectron-gui/node_modules/electron-builder/index.js:45:10)
    at Object.<anonymous> (/Users/maxcnunes/Development/sqlectron/sqlectron-gui/node_modules/electron-builder/cli.js:36:9)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Function.Module.runMain (module.js:501:10)
    at startup (node.js:129:16)
```
