### PR TITLE
fix invalid json format in readme for config.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ config.json.sample:
     "version" : "x.x.x.x",
     "icon" : "assets/win/icon.ico",
     "verbosity": 1,
-    "nsiTemplate" : "path/to/custom/installer.nsi.tpl", // optional
-    "fileAssociation": { // optional
+    "nsiTemplate" : "path/to/custom/installer.nsi.tpl",
+    "fileAssociation": {
       "extension": ".loop",
       "fileType": "Loopline Systems File"
     }

--- a/index.js
+++ b/index.js
@@ -28,8 +28,8 @@ var Builder = {
 
     options     = options || {};
     options.log = options.log || console.log;
-    options.out = options.out 
-                  ? path.resolve( process.cwd(), options.out ) 
+    options.out = options.out
+                  ? path.resolve( process.cwd(), options.out )
                   : process.cwd();
 
     options.log(
@@ -66,7 +66,7 @@ var Builder = {
       try {
         options.config = require( configPath );
       } catch( error ) {
-        return callback( new Error( 'Could not load config file' ) );
+        throw error;
       }
     }
 


### PR DESCRIPTION
if users copy and paste the example config.json in the readme, they will run into a build error due to ``// optional`` comments:

```
Error: Could not load config file
```

This pull request just removes those comments so that it turns it back into valid json format
