### PR TITLE
Add option win.encoding for .nsi templates, dealing with Umlauts or chars with accent.

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,12 @@ Option to define a custom file association on Windows.
 Caution: when you use `win.nsiTemplate` option, `win.fileAssociation` option should only work
 if the custom nsi template is based on the original one.
 
+### `win.encoding` *( optional )*
+Option to define a custom encoding for output template.nsi on Windows.
+Default value is 'UTF-8'.
+For available values see [node-iconv's page](https://github.com/bnoordhuis/node-iconv).
+The packager.json config should always be UTF8 encoded.
+
 **Note:** You need to add something that might have value for others? Please consider a PR. ;)
 
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ if the custom nsi template is based on the original one.
 ### `win.encoding` *( optional )*
 Option to define a custom encoding for output template.nsi on Windows.
 Default value is 'UTF-8'.
-For available values see [node-iconv's page](https://github.com/bnoordhuis/node-iconv).
+For available values see [ashtuchkin/iconv-lite's page](https://github.com/ashtuchkin/iconv-lite/wiki/Supported-Encodings).
 The packager.json config should always be UTF8 encoded.
 
 **Note:** You need to add something that might have value for others? Please consider a PR. ;)

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ if the custom nsi template is based on the original one.
 Option to define a custom encoding for output template.nsi on Windows.
 Default value is 'UTF-8'.
 For available values see [ashtuchkin/iconv-lite's page](https://github.com/ashtuchkin/iconv-lite/wiki/Supported-Encodings).
-The packager.json config should always be UTF8 encoded.
+The provided template for the installer script (.nsi) should always be UTF8 encoded.
 
 **Note:** You need to add something that might have value for others? Please consider a PR. ;)
 

--- a/lib/helper/writeConfigFile.js
+++ b/lib/helper/writeConfigFile.js
@@ -11,6 +11,7 @@ var fs       = require( 'fs' );
 var template = require( 'lodash.template' );
 var os       = require( 'os' );
 var path     = require( 'path' );
+var Iconv    = require( 'iconv' ).Iconv;
 
 
 /**
@@ -37,14 +38,21 @@ module.exports = function( templatePath, options ) {
     }
   )( options );
 
-  var outputPath = path.join( 
-      os.tmpDir(), 
+  var outputPath = path.join(
+      os.tmpDir(),
       ( Math.random() * 1e32 ).toString( 36 ) + path.basename( '.tpl' )
     );
 
+  var configEncoded = config;
+  var converter;
+  if( options.encoding ){
+    converter = new Iconv( 'UTF-8', options.encoding );
+    configEncoded = converter.convert( config );
+  }
+
   fs.writeFileSync(
     outputPath,
-    config,
+    configEncoded,
     {
       encoding : 'utf8'
     }

--- a/lib/helper/writeConfigFile.js
+++ b/lib/helper/writeConfigFile.js
@@ -11,7 +11,7 @@ var fs       = require( 'fs' );
 var template = require( 'lodash.template' );
 var os       = require( 'os' );
 var path     = require( 'path' );
-var Iconv    = require( 'iconv' ).Iconv;
+var iconv    = require( 'iconv-lite' );
 
 
 /**
@@ -44,10 +44,8 @@ module.exports = function( templatePath, options ) {
     );
 
   var configEncoded = config;
-  var converter;
-  if( options.encoding ){
-    converter = new Iconv( 'UTF-8', options.encoding );
-    configEncoded = converter.convert( config );
+  if( options.encoding && iconv.encodingExists( options.encoding ) ){
+    configEncoded = iconv.encode( config, options.encoding.toLowerCase() );
   }
 
   fs.writeFileSync(

--- a/lib/win.js
+++ b/lib/win.js
@@ -41,7 +41,8 @@ var WinBuilder = {
       version         : win.version,
       fileAssociation : win.fileAssociation,
       publisher       : win.publisher,
-      out             : _windowsify( options.out )
+      out             : _windowsify( options.out ),
+      encoding        : win.encoding
     } );
 
     _copyAssetsToTmpFolder( options );

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "homepage": "https://github.com/loopline-systems/electron-builder",
   "dependencies": {
     "fs-extra": "^0.26.0",
-    "iconv": "^2.1.11",
+    "iconv-lite": "^0.4.13",
     "lodash.assign": "^3.2.0",
     "lodash.camelcase": "^3.0.1",
     "lodash.template": "^3.6.1",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "homepage": "https://github.com/loopline-systems/electron-builder",
   "dependencies": {
     "fs-extra": "^0.26.0",
+    "iconv": "^2.1.11",
     "lodash.assign": "^3.2.0",
     "lodash.camelcase": "^3.0.1",
     "lodash.template": "^3.6.1",


### PR DESCRIPTION
As the `makensis` does not support full utf8 encoding, I added the possibility (via `iconv`) to specifiy a encoding which should be exported by electron-builder before invoking `makensis`.
In your `packager.json` just specify `win.encoding`. (e.g. `win.encoding = "ISO-8859-1"`)
This allows usage of Umlauts ö,ä,ü or accents without pain.

If there is any interest in this you can just merge with this request. I based it upon `0.2.6, if you need a version based on master (which is not running for me atm) then let me know.

**Edit:**
Sorry for the confusion. I deleted the first pull request, because I did the commits with the wrong user set up.