### PR TITLE
Linux deb: version and arch should be replaced in the out file name, …

### DIFF
--- a/lib/linux.js
+++ b/lib/linux.js
@@ -41,18 +41,23 @@ var LinuxBuilder = {
       linux.archName = 'x86_64';
     }
 
-    var tmpFolder = path.join( os.tmpDir(), linux.executable );
+    var outFilename = linux.executable + '-' +
+                      linux.version + '-' + linux.archName + '.' +
+                      linux.target;
+    var tmpFolder = path.join( os.tmpDir(), outFilename );
     _createFolders( tmpFolder );
 
     _createDesktopEntry( tmpFolder, linux );
 
     var scripts = _createScripts( linux );
 
-    _copyApp( options, tmpFolder );
+    fs.copySync( options.appPath,
+      path.join( tmpFolder, 'opt', options.config.linux.executable ) );
 
-    _buildPackage( options, scripts, tmpFolder );
+    var destination = path.join( options.out, outFilename );
+    _buildPackage( options, scripts, tmpFolder, destination );
 
-    callback();
+    callback( null, destination );
   }
 };
 
@@ -62,12 +67,8 @@ var LinuxBuilder = {
  * @param {String} tmpFolder  folder where the packaged app is built
  */
 function _createFolders( tmpFolder ) {
-  fs.removeSync( tmpFolder );
-  fs.mkdirpSync( tmpFolder );
-  var usrShare = path.join( tmpFolder, 'usr', 'share' );
-  fs.mkdirpSync( path.join( usrShare, 'applications' ) );
-  fs.mkdirpSync( path.join( usrShare, 'icons', 'hicolors' ) );
-  fs.mkdirpSync( path.join( tmpFolder, 'opt' ) );
+  fs.emptyDirSync( tmpFolder );
+  fs.mkdirpSync( path.join( tmpFolder, 'usr', 'share', 'icons', 'hicolors' ) );
 }
 
 /**
@@ -90,7 +91,7 @@ function _createDesktopEntry( tmpFolder, linux ) {
   var tplFile = fs.readFileSync( desktopEntryTemplate, 'utf8' );
   var tpl = template( tplFile );
   var merge = tpl( linux );
-  fs.writeFileSync( dest, merge, 'utf8' );
+  fs.outputFileSync( dest, merge );
 }
 
 /**
@@ -118,29 +119,15 @@ function _createScripts ( linux ) {
 }
 
 /**
- * Copy the app in the given folder
- *
- * @param {Object} options options
- * @param {String} tmpFolder  temp folder where the app is assembled
- */
-function _copyApp( options, tmpFolder ) {
-  fs.copySync(
-    path.resolve( options.appPath ),
-    path.join( tmpFolder, 'opt', options.config.linux.executable )
-  );
-}
-
-/**
  * Build the package
  *
  * @param {Object} options options
  * @param {Array}  scripts paths to scripts
  * @param {String} tmpFolder  temp folder where the app is assembled
+ * @param {String} destination The package file path to output.
  */
-function _buildPackage( options, scripts, tmpFolder ) {
+function _buildPackage( options, scripts, tmpFolder, destination ) {
   var linux = options.config.linux;
-  var file = linux.executable + '-VERSION-ARCH.' + linux.target;
-  var dest = path.join( options.out, file );
   var args = [
     '-s dir',
     '-t ' + linux.target,
@@ -153,7 +140,7 @@ function _buildPackage( options, scripts, tmpFolder ) {
     '--description "' + linux.comment + '"',
     '--maintainer "' + linux.maintainer + '"',
     '--version "' + linux.version + '"',
-    '--package "' + dest + '"',
+    '--package "' + destination + '"',
     '-C ' + tmpFolder,
     '.'
   ];


### PR DESCRIPTION
Version and arch should be replaced in the out file name. Otherwise it is not possible to build package for several arch (because name will be the same).

Full name must be used to generate temp directory name, otherwise it is not possible to build in parallel (electron-complete-builder tests (AVA test runner) and build performed in parallel to speed up).