### PR TITLE
Linux deb target: print real error message

### DIFF
--- a/lib/linux.js
+++ b/lib/linux.js
@@ -30,7 +30,6 @@ var LinuxBuilder = {
 
     var linux = options.config.linux;
 
-    var archName;
     if ( linux.arch === 32 ) {
       linux.archName = 'i386';
     }
@@ -50,14 +49,8 @@ var LinuxBuilder = {
     _createDesktopEntry( tmpFolder, linux );
 
     var scripts = _createScripts( linux );
-
-    fs.copySync( options.appPath,
-      path.join( tmpFolder, 'opt', options.config.linux.executable ) );
-
     var destination = path.join( options.out, outFilename );
-    _buildPackage( options, scripts, tmpFolder, destination );
-
-    callback( null, destination );
+    _buildPackage( options, scripts, tmpFolder, destination, callback );
   }
 };
 
@@ -125,32 +118,39 @@ function _createScripts ( linux ) {
  * @param {Array}  scripts paths to scripts
  * @param {String} tmpFolder  temp folder where the app is assembled
  * @param {String} destination The package file path to output.
+ * @param callback
  */
-function _buildPackage( options, scripts, tmpFolder, destination ) {
+function _buildPackage( options, scripts, tmpFolder, destination, callback ) {
   var linux = options.config.linux;
+  var installPath = 'opt/' + linux.executable;
   var args = [
-    '-s dir',
-    '-t ' + linux.target,
-    '--architecture ' + linux.archName,
-    '--rpm-os linux',
-    '--name "' + linux.title + '"',
+    '-s', 'dir',
+    '-t', linux.target,
+    '--architecture', linux.archName,
+    '--rpm-os', 'linux',
+    '--name', linux.title,
     '--force',
-    '--after-install ' + scripts[0],
-    '--after-remove ' + scripts[1],
-    '--description "' + linux.comment + '"',
-    '--maintainer "' + linux.maintainer + '"',
-    '--version "' + linux.version + '"',
-    '--package "' + destination + '"',
-    '-C ' + tmpFolder,
-    '.'
+    '--after-install', scripts[0],
+    '--after-remove', scripts[1],
+    '--description',  linux.comment,
+    '--maintainer', linux.maintainer,
+    '--version', linux.version,
+    '--package', destination,
+    tmpFolder + '/=/',
+    path.resolve( options.appPath ) + '/=/' + installPath
   ];
 
-  fs.writeFileSync(
-    path.join( tmpFolder, 'opt', linux.executable, 'pkgtarget' ),
-    linux.target,
-    'utf8'
+  fs.outputFileSync(
+    path.join( tmpFolder, installPath, 'pkgtarget' ),
+    linux.target
   );
-  childProcess.execSync( 'fpm ' + args.join( ' ' ) );
+  childProcess.execFile( 'fpm', args, function ( error, stdout, stderr ) {
+    if ( error != null ) {
+      console.error( stdout.toString() );
+      console.error( stderr.toString() );
+    }
+    callback( error, destination );
+  } );
 }
 
 /**

--- a/lib/linux.js
+++ b/lib/linux.js
@@ -136,6 +136,7 @@ function _buildPackage( options, scripts, tmpFolder, destination, callback ) {
     '--maintainer', linux.maintainer,
     '--version', linux.version,
     '--package', destination,
+    '--deb-compression', linux.compression || 'xz',
     tmpFolder + '/=/',
     path.resolve( options.appPath ) + '/=/' + installPath
   ];


### PR DESCRIPTION
I got error:

```
  1. linux
  Error: Command failed: fpm -s dir -t deb --architecture i386 --rpm-os linux --name "TestApp" --force --after-install /var/folders/gw/_2jq29095y7b__wtby9dg_5h0000gn/T/4m9i3y9haqass4osg8404.tpl --after-remove /var/folders/gw/_2jq29095y7b__wtby9dg_5h0000gn/T/6zn80qw760sgscggoggww.tpl --description "Test Application" --maintainer "Foo Bar" --version "1.0.0" --package "/Users/travis/build/develar/electron-complete-builder/test/fixtures/test-app-one/dist/TestApp-1.0.0-i386.deb" -C /var/folders/gw/_2jq29095y7b__wtby9dg_5h0000gn/T/TestApp-1.0.0-i386.deb .
    Error: Command failed: fpm -s dir -t deb --architecture i386 --rpm-os linux --name "TestApp" --force --after-install /var/folders/gw/_2jq29095y7b__wtby9dg_5h0000gn/T/4m9i3y9haqass4osg8404.tpl --after-remove /var/folders/gw/_2jq29095y7b__wtby9dg_5h0000gn/T/6zn80qw760sgscggoggww.tpl --description "Test Application" --maintainer "Foo Bar" --version "1.0.0" --package "test/fixtures/test-app-one/dist/TestApp-1.0.0-i386.deb" -C /var/folders/gw/_2jq29095y7b__wtby9dg_5h0000gn/T/TestApp-1.0.0-i386.deb .
        checkExecSyncError (child_process.js:464:13)
```

As you can see, it is unclear and doesn't contain real error message from fpm. No idea how to fix.

So, we must print `stderr` and `stdout` on error.

What do you get after my fix:

```
  ✖ BuildTest › linux failed with "Command failed: fpm -s dir -t deb --architecture i386 --rpm-os linux --name TestApp --force --deb-compression xz --after-install /var/folders/gw/_2jq29095y7b__wtby9dg_5h0000gn/T/5g45kbi7r484kc00ocsgs.tpl --after-remove /var/folders/gw/_2jq29095y7b__wtby9dg_5h0000gn/T/6qsfqfvdsjs40osgk0ocw.tpl --description Test Application --maintainer Foo Bar --version 1.0.0 --package /Users/travis/build/develar/electron-complete-builder/test/fixtures/test-app-one/dist/TestApp-1.0.0-i386.deb /var/folders/gw/_2jq29095y7b__wtby9dg_5h0000gn/T/TestApp-1.0.0-i386.deb /Users/travis/build/develar/electron-complete-builder/test/fixtures/test-app-one/dist/TestApp-linux-ia32=/opt/TestApp
"
{:timestamp=>"2016-02-12T11:29:30.193881+0000", :message=>"Debian tools (dpkg/apt) don't do well with packages that use capital letters in the name. In some cases it will automatically downcase them, in others it will not. It is confusing. Best to not use any capital letters at all. I have downcased the package name for you just to be safe.", :oldname=>"TestApp", :fixedname=>"testapp", :level=>:warn}
{:timestamp=>"2016-02-12T11:29:30.274572+0000", :message=>"Debian packaging tools generally labels all files in /etc as config files, as mandated by policy, so fpm defaults to this behavior for deb packages. You can disable this default behavior with --deb-no-default-config-files flag", :level=>:warn}
{:timestamp=>"2016-02-12T11:29:30.908444+0000", :message=>"Need executable '[\"gnutar\", \"gtar\"]' to convert dir to deb", :level=>:error}
```

Clear error message and user have an idea how to fix it.

Please note — `electron-builder` doesn't have tests, but is is covered by my project `electron-complete-builder` — see https://github.com/develar/electron-complete-builder/blob/windows-code-signing/test/BuildTest.js#L84 (our project will be merged soon, anyway).