### PR TITLE
use node Object.assign instead of lodash.assign

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -11,7 +11,6 @@
 
 var fs      = require( 'fs' );
 var meow    = require( 'meow' );
-var assign  = require( 'lodash.assign' );
 var path    = require( 'path' );
 
 var builder = ( require( './' ) ).init();
@@ -54,7 +53,7 @@ try {
 
 var basePath = path.dirname( configPath );
 
-builder.build( assign( cli.flags, {
+builder.build( Object.assign( cli.flags, {
   appPath  : appPath,
   config   : config,
   basePath : basePath

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "gm": "^1.21.1",
     "hosted-git-info": "^2.1.4",
     "json-parse-helpfulerror": "^1.0.3",
-    "lodash.assign": "^4.0.2",
     "lodash.camelcase": "^4.0.1",
     "lodash.template": "^4.1.1",
     "meow": "^3.7.0",


### PR DESCRIPTION
Stable node 4 and latest 5 supports `Object.assign`, so, we don't need to use lodash.