### PR TITLE
Fix error on win when APP_OUT_FILE has spaces

### DIFF
--- a/templates/win/installer.nsi.tpl
+++ b/templates/win/installer.nsi.tpl
@@ -23,7 +23,7 @@ Name "${APP_NAME}"
 BrandingText "${APP_NAME} ${APP_VERSION}"
 
 # define the resulting installer's name
-OutFile ${APP_OUT_FILE}
+OutFile "${APP_OUT_FILE}"
 
 # set the installation directory
 InstallDir "$PROGRAMFILES\${APP_NAME}\"


### PR DESCRIPTION
When the application name has spaces "My App Setup.exe" then the call to `makensis` fails with "OutFile expects 1 parameters".  Adding quotes seems to fix the issue.

```bash
- Running electron-builder 2.8.2
- Starting creation of installer for ´win
makensis: OutFile expects 1
makensis:  parameters, got 3.

makensis: Usage: OutFile install_output.exe

makensis: Error in script "C:\Users\Me\AppData\Local\Temp\1ve60rr549uokok0ogwg.tpl" on line 23 -- aborting creation process
```