### PR TITLE
fix(nsis): error on win when APP_OUT_FILE has spaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "fs-extra": "^0.26.5",
     "gm": "^1.21.1",
     "hosted-git-info": "^2.1.4",
-    "lodash.template": "^4.2.0",
+    "lodash.template": "^4.2.1",
     "meow": "^3.7.0",
     "mime": "^1.3.4",
     "progress": "^1.1.8",

--- a/templates/win/installer.nsi.tpl
+++ b/templates/win/installer.nsi.tpl
@@ -23,7 +23,7 @@ Name "${APP_NAME}"
 BrandingText "${APP_NAME} ${APP_VERSION}"
 
 # define the resulting installer's name
-OutFile ${APP_OUT_FILE}
+OutFile "${APP_OUT_FILE}"
 
 # set the installation directory
 InstallDir "$PROGRAMFILES\${APP_NAME}\"

--- a/test/fixtures/test-app-one/package.json
+++ b/test/fixtures/test-app-one/package.json
@@ -17,6 +17,9 @@
     "linux": {
       "//": "gz is much faster, in tests we don't need efficient compression",
       "compression": "gz"
+    },
+    "win": {
+      "title": "My App"
     }
   }
 }


### PR DESCRIPTION
test(nsis): add app title with spaces

But we don't allow/support to set custom ourFile name in the new API — we use package.json name — cannot have spaces.
Since old API is deprecated, test will be not added to cover this case.