### PR TITLE
Use productName from app/package.json if present

### DIFF
--- a/src/packager.ts
+++ b/src/packager.ts
@@ -55,6 +55,9 @@ export class Packager implements BuildInfo {
     await BluebirdPromise.all(Array.from(new Set([buildPackageFile, appPackageFile]), readPackageJson))
       .then(result => {
         this.metadata = result[result.length - 1]
+        if (this.metadata.productName) {
+          this.metadata.name = this.metadata.productName
+        }
         this.devMetadata = result[0]
         this.checkMetadata(appPackageFile, platforms)
 

--- a/src/repositoryInfo.ts
+++ b/src/repositoryInfo.ts
@@ -22,6 +22,7 @@ export interface MetadataAuthor {
 export interface AppMetadata extends Metadata {
   version: string
   name: string
+  productName: string
   description: string
   author: MetadataAuthor
 


### PR DESCRIPTION
This allows you to specify a `productName` for your executable which contains spaces and other special characters not allowed in the `name` property.

This matches similar behavior already present in electron-packager: https://github.com/electron-userland/electron-packager/blob/d49b932d88fee06173535efdcab225de98bfe95b/index.js#L59