### PR TITLE
Allow custom .p12 certificates

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -32,6 +32,9 @@ export function build(options: BuildOptions = {}): Promise<any> {
   if (options.cscLink == null) {
     options.cscLink = process.env.CSC_LINK
   }
+  if (options.csaLink == null) {
+    options.csaLink = process.env.CSA_LINK
+  }
   if (options.cscKeyPassword == null) {
     options.cscKeyPassword = process.env.CSC_KEY_PASSWORD
   }

--- a/src/codeSign.ts
+++ b/src/codeSign.ts
@@ -24,13 +24,13 @@ export function generateKeychainName(): string {
   return "csc-" + randomString() + ".keychain"
 }
 
-export function createKeychain(keychainName: string, cscLink: string, cscKeyPassword: string): Promise<CodeSigningInfo> {
-  const appleCertPath = path.join(tmpdir(), randomString() + ".cer")
+export function createKeychain(keychainName: string, cscLink: string, cscKeyPassword: string, csaLink: string): Promise<CodeSigningInfo> {
+  const authorityCertPath = path.join(tmpdir(), randomString() + ".cer")
   const developerCertPath = path.join(tmpdir(), randomString() + ".p12")
 
   const keychainPassword = randomString()
   return executeFinally(Promise.all([
-      download("https://developer.apple.com/certificationauthority/AppleWWDRCA.cer", appleCertPath),
+      download(csaLink || "https://developer.apple.com/certificationauthority/AppleWWDRCA.cer", authorityCertPath),
       download(cscLink, developerCertPath),
       BluebirdPromise.mapSeries([
         ["create-keychain", "-p", keychainPassword, keychainName],
@@ -38,9 +38,9 @@ export function createKeychain(keychainName: string, cscLink: string, cscKeyPass
         ["set-keychain-settings", "-t", "3600", "-u", keychainName]
       ], it => exec("security", it))
     ])
-    .then(() => importCerts(keychainName, appleCertPath, developerCertPath, cscKeyPassword)),
+    .then(() => importCerts(keychainName, authorityCertPath, developerCertPath, cscKeyPassword)),
     error => {
-      const tasks = [deleteFile(appleCertPath, true), deleteFile(developerCertPath, true)]
+      const tasks = [deleteFile(authorityCertPath, true), deleteFile(developerCertPath, true)]
       if (error != null) {
         tasks.push(deleteKeychain(keychainName))
       }
@@ -48,8 +48,8 @@ export function createKeychain(keychainName: string, cscLink: string, cscKeyPass
     })
 }
 
-async function importCerts(keychainName: string, appleCertPath: string, developerCertPath: string, cscKeyPassword: string): Promise<CodeSigningInfo> {
-  await exec("security", ["import", appleCertPath, "-k", keychainName, "-T", "/usr/bin/codesign"])
+async function importCerts(keychainName: string, authorityCertPath: string, developerCertPath: string, cscKeyPassword: string): Promise<CodeSigningInfo> {
+  await exec("security", ["import", authorityCertPath, "-k", keychainName, "-T", "/usr/bin/codesign"])
   await exec("security", ["import", developerCertPath, "-k", keychainName, "-T", "/usr/bin/codesign", "-P", cscKeyPassword])
   let cscName = await extractCommonName(cscKeyPassword, developerCertPath)
   return {

--- a/src/macPackager.ts
+++ b/src/macPackager.ts
@@ -17,7 +17,7 @@ export default class MacPackager extends PlatformPackager<appdmg.Specification> 
     if (this.options.cscLink != null && this.options.cscKeyPassword != null) {
       const keychainName = generateKeychainName()
       cleanupTasks.push(() => deleteKeychain(keychainName))
-      this.codeSigningInfo = createKeychain(keychainName, this.options.cscLink, this.options.cscKeyPassword)
+      this.codeSigningInfo = createKeychain(keychainName, this.options.cscLink, this.options.cscKeyPassword, this.options.csaLink)
     }
     else {
       this.codeSigningInfo = BluebirdPromise.resolve(null)

--- a/src/platformPackager.ts
+++ b/src/platformPackager.ts
@@ -42,6 +42,7 @@ export interface PackagerOptions {
   projectDir?: string
 
   cscLink?: string
+  csaLink?: string
   cscKeyPassword?: string
 }
 


### PR DESCRIPTION
This patch enables signing OSX apps with custom .p12 certificates issued by trusted CA.

Added:
- Environment variable CSA_LINK
- config.csaLink option
- config.csaLink falls back to Apple CA by default