### PR TITLE
fix: ignore newline when parsing common name in .p12 certificates

### DIFF
--- a/src/codeSign.ts
+++ b/src/codeSign.ts
@@ -60,7 +60,7 @@ async function importCerts(keychainName: string, authorityCertPath: string, deve
 function extractCommonName(password: string, certPath: string): BluebirdPromise<string> {
   return exec("openssl", ["pkcs12", "-nokeys", "-nodes", "-passin", "pass:" + password, "-nomacver", "-clcerts", "-in", certPath])
     .then(result => {
-      const match = result[0].toString().match(/^subject.*\/CN=([^\/]+)/m)
+      const match = result[0].toString().match(/^subject.*\/CN=([^\/\n]+)/m)
       if (match == null || match[1] == null) {
         throw new Error("Cannot extract common name from p12")
       }


### PR DESCRIPTION
The regex takes an extra newline when parsing the .p12 cert common name, in this example:

subject=/C=CY/L=Limassol/O=OrgName/CN=OrgName
issuer=/C=US/O=DigiCert

Common name ends up being: 
OrgName
issuer=

Expected:
OrgName