### PR TITLE
fix: npm install doesn't rebuild native dependencies if arch changed …

### DIFF
--- a/src/install-app-deps.ts
+++ b/src/install-app-deps.ts
@@ -14,5 +14,5 @@ const devPackageFile = path.join(process.cwd(), "package.json")
 const appDir = args.appDir || DEFAULT_APP_DIR_NAME
 
 readPackageJson(devPackageFile)
-  .then(it => installDependencies(path.join(process.cwd(), appDir), args.arch, getElectronVersion(it, devPackageFile)))
+  .then(it => installDependencies(path.join(process.cwd(), appDir), getElectronVersion(it, devPackageFile), args.arch))
   .catch(printErrorAndExit)

--- a/src/packager.ts
+++ b/src/packager.ts
@@ -165,7 +165,7 @@ export class Packager implements BuildInfo {
 
   private installAppDependencies(arch: string): Promise<any> {
     if (this.isTwoPackageJsonProjectLayoutUsed) {
-      return installDependencies(this.appDir, arch, this.electronVersion)
+      return installDependencies(this.appDir, this.electronVersion, arch, "rebuild")
     }
     else {
       log("Skipping app dependencies installation because dev and app dependencies are not separated")

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,8 @@
 import { execFile, spawn as _spawn } from "child_process"
 import { Promise as BluebirdPromise } from "bluebird"
 import readPackageJsonAsync = require("read-package-json")
+import * as os from "os"
+import * as path from "path"
 
 export const log = console.log
 
@@ -14,21 +16,20 @@ export const commonArgs: any[] = [{
 
 export const readPackageJson = BluebirdPromise.promisify(readPackageJsonAsync)
 
-export function installDependencies(appDir: string, arch: string, electronVersion: string): BluebirdPromise<any> {
-  log("Installing app dependencies for arch %s to %s", arch || process.arch, appDir)
+export function installDependencies(appDir: string, electronVersion: string, arch: string = process.arch, command: string = "install"): BluebirdPromise<any> {
+  log("Installing app dependencies for arch %s to %s", arch, appDir)
+  const gypHome = path.join(os.homedir(), ".electron-gyp")
   const env = Object.assign({}, process.env, {
     npm_config_disturl: "https://atom.io/download/atom-shell",
     npm_config_target: electronVersion,
     npm_config_runtime: "electron",
-    HOME: require("os").homedir() + "/.electron-gyp",
+    npm_config_arch: arch,
+    HOME: gypHome,
+    USERPROFILE: gypHome,
   })
 
-  if (arch != null) {
-    env.npm_config_arch = arch
-  }
-
   let npmExecPath = process.env.npm_execpath || process.env.NPM_CLI_JS
-  const npmExecArgs = ["install"]
+  const npmExecArgs = [command, "--production"]
   if (npmExecPath == null) {
     npmExecPath = "npm"
   }


### PR DESCRIPTION
fix: npm install doesn't rebuild native dependencies if arch changed — rebuild must be used