### PR TITLE
fix: Linux build fails at icon conversion #239

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "ava-tf": "^0.12.4-beta.6",
     "babel-plugin-array-includes": "^2.0.3",
     "babel-plugin-transform-es2015-parameters": "^6.7.0",
-    "electron-download": "^2.0.0",
+    "electron-download": "^2.1.0",
     "eslint": "^2.4.0",
     "eslint-plugin-ava": "sindresorhus/eslint-plugin-ava",
     "ghooks": "^1.0.3",


### PR DESCRIPTION
Closes #239

Well, it is not a real fix, because it seems that icns2png is completely broken on Linux (ironically, yes :()
Unlikely that it will be merged in this form.