### PR TITLE
refactor: use windows-installer instead of fork.

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "bluebird": "^3.3.4",
     "command-line-args": "^2.1.6",
     "electron-packager-tf": "^5.2.3",
-    "electron-winstaller-fixed": "^2.0.5-beta.7",
+    "electron-winstaller": "^2.0.5",
     "fs-extra": "^0.26.5",
     "fs-extra-p": "^0.1.0",
     "globby": "^4.0.0",


### PR DESCRIPTION
Replaced a fork with electron-winstaller. Let's wait for tests, because I have troubles with running them on my windows machine.